### PR TITLE
Added an alt valid schema (role_arn & source_profile) to addProfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,8 +102,8 @@ class awsProfileHandler {
         }
 
         if (Object.keys(credentials).length !== 2 ||
-            !credentials.hasOwnProperty('aws_access_key_id') ||
-            !credentials.hasOwnProperty('aws_secret_access_key')) {
+            !this.isValidSchema(credentials) &&
+            !this.isValidAltSchema(credentials)) {
             throw new Error('Invalid input: credentials schema is invalid.');
         }
 
@@ -115,6 +115,14 @@ class awsProfileHandler {
         let encodedProfile = Ini.encodeIniFormat(outputProfileObject);
         Utils.writeFile(credentialPath, encodedProfile);
     }
+
+    static isValidSchema(credentials) {
+        return (credentials.hasOwnProperty('aws_access_key_id') && credentials.hasOwnProperty('aws_secret_access_key'))
+    }
+
+    static isValidAltSchema(credentials) {
+        return (credentials.hasOwnProperty('role_arn') && credentials.hasOwnProperty('source_profile'))
+    }    
 }
 module.exports = awsProfileHandler;
 

--- a/lib/ini.js
+++ b/lib/ini.js
@@ -60,7 +60,7 @@ class Ini {
                 iniContentList.push("[" + sessionName + "]");
 
                 let listChild = _flattenObject(sessionObject[sessionName]);
-                return iniContentList.concat(listChild);
+                return iniContentList.concat(listChild, '');
             }, []);
         return encodedIniContentList.join('\n');
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,6 +30,26 @@ let addedObject = {
         "keys": "b"
     }
 };
+let addedObjectAltSchema = {
+    "happyCase": {
+        "role_arn": "a",
+        "source_profile": "b"
+    },
+    "emptyObject": {
+    },
+    "missingOneKey": {
+        "source_profile": "a",
+    },
+    "containsOneExtraKey": {
+        "role_arn": "a",
+        "source_profile": "b",
+        "extra": 123
+    },
+    "wrongKeys": {
+        "wrong": "a",
+        "keys": "b"
+    }
+};
 let childObject = {
     "default": {
         "key1": "val1",
@@ -227,6 +247,79 @@ describe('V2 awsProfileHandler unit test', () => {
                 .toThrowError('Invalid input: credentials schema is invalid.');
         });
     })
+
+    describe('addProfile - alt schema', () => {
+        it ('happy case', () => {
+            let expected_result = {
+                "default": childObject.default,
+                "awesome": {
+                    "aaron": "that's me"
+                },
+                "add": addedObjectAltSchema.happyCase
+            };
+            awsProfileHandler.addProfile("add", addedObjectAltSchema.happyCase);
+            expect(Utils.writeFile).toBeCalled();
+            expect(Ini.encodeIniFormat)
+                .toBeCalledWith(expected_result);
+        });
+
+
+        it('should throw error if input profile is missing', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile();
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid Input: profile name cannot be omitted nor only contains white spaces.');
+        });
+
+        it('should throw error if input profile is only white space', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile("\n\t  ");
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid Input: profile name cannot be omitted nor only contains white spaces.');
+        });
+
+        it('should throw error if input credentials is missing', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile('profile');
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid Input: credentials cannot be omitted nor empty.');
+        });
+
+        it('should throw error if input credentials is empty', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile('profile', addedObjectAltSchema.emptyObject);
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid Input: credentials cannot be omitted nor empty.');
+        });
+
+        it('should throw error if input credentials is missing one key', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile('profile', addedObjectAltSchema.missingOneKey);
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid input: credentials schema is invalid.');
+        });
+
+        it('should throw error if input credentials has extra keys', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile('profile', addedObjectAltSchema.containsOneExtraKey);
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid input: credentials schema is invalid.');
+        });
+
+        it('should throw error if input credentials object has wrong keys', () => {
+            function invalidInput() {
+                return awsProfileHandler.addProfile('profile', addedObjectAltSchema.wrongKeys);
+            }
+            expect(invalidInput)
+                .toThrowError('Invalid input: credentials schema is invalid.');
+        });
+    })    
 });
 
 describe('awsProfileHandler unit test', () => {

--- a/test/lib/ini.test.js
+++ b/test/lib/ini.test.js
@@ -20,9 +20,11 @@ describe('Ini module unit test', () => {
         "aws_access_key_id=123\n" +
         "aws_secret_access_key=321\n" +
         "region=us-east-1\n" +
+        "\n" +
         "[test]\n" +
         "aws_access_key_id=12345\n" +
-        "aws_secret_access_key=12345";
+        "aws_secret_access_key=12345" +
+        "\n";
 
     const withCommentsIniTextFormat =
         "# start comments\n" +


### PR DESCRIPTION
Both schema are valid as so should be able to add a profile using the alt schema:

[dev-admin]
role_arn = arn:aws:iam::555555555:role/admin
source_profile = master-user

[master-user]
aws_access_key_id = a
aws_secret_access_key = b