### PR TITLE
Added blank line between sections

### DIFF
--- a/lib/ini.js
+++ b/lib/ini.js
@@ -60,7 +60,7 @@ class Ini {
                 iniContentList.push("[" + sessionName + "]");
 
                 let listChild = _flattenObject(sessionObject[sessionName]);
-                return iniContentList.concat(listChild);
+                return iniContentList.concat(listChild, '');
             }, []);
         return encodedIniContentList.join('\n');
     }

--- a/test/lib/ini.test.js
+++ b/test/lib/ini.test.js
@@ -20,9 +20,11 @@ describe('Ini module unit test', () => {
         "aws_access_key_id=123\n" +
         "aws_secret_access_key=321\n" +
         "region=us-east-1\n" +
+        "\n" +
         "[test]\n" +
         "aws_access_key_id=12345\n" +
-        "aws_secret_access_key=12345";
+        "aws_secret_access_key=12345" +
+        "\n";
 
     const withCommentsIniTextFormat =
         "# start comments\n" +


### PR DESCRIPTION
My credentials file had spaces in it before writing to it with aws-profiler-handler which then clobbered those blanks. Would be nice to have a more readable file with blank spaces separating the sections.